### PR TITLE
Enhance calendar with REST API and settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,9 @@
 - Initial object-oriented plugin structure.
 - Moved CSS and JS to dedicated files.
 - Added nonce protection and vanilla JS.
+
+## 1.1.0
+- Added admin settings page for template ID and datepicker toggle.
+- Switched AJAX to REST API with transient caching.
+- Conditional asset loading and Flatpickr integration.
+- Added Gutenberg block and deep-linking via URL params.

--- a/assets/js/blocks.js
+++ b/assets/js/blocks.js
@@ -1,0 +1,14 @@
+(function(blocks,i18n,element,blockEditor){
+    const el = element.createElement;
+    blocks.registerBlockType('vg-events/calendar',{
+        title: 'Events Calendar',
+        icon: 'calendar-alt',
+        category: 'widgets',
+        edit: function(){
+            return el('div', {}, '[custom_loop_code_sidebar]');
+        },
+        save: function(){
+            return null;
+        }
+    });
+})(window.wp.blocks, window.wp.i18n, window.wp.element, window.wp.blockEditor);

--- a/templates/shortcode.php
+++ b/templates/shortcode.php
@@ -29,22 +29,10 @@ $post_types = isset($this) ? $this->post_types : [];
             <h5><br><br>DORP</h5>
             <select id="town-filter">
                 <option value="">Dorp</option>
-                <?php
-                $towns = array('Bloemfontein','Centurion','Kaapstad','Kemptonpark','Klerksdorp','Krugersdorp','Pretoria','Vanderbijlpark','Vereeniging');
-                foreach ($towns as $town) {
-                    echo '<option value="' . esc_attr($town) . '">' . esc_html($town) . '</option>';
-                }
-                ?>
             </select>
             <h5><br><br>MAAND</h5>
             <select id="month-filter">
                 <option value="">Maand</option>
-                <?php
-                $months = array('01'=>'Januarie','02'=>'Februarie','03'=>'Maart','04'=>'April','05'=>'Mei','06'=>'Junie','07'=>'Julie','08'=>'Augustus','09'=>'September','10'=>'Oktober','11'=>'November','12'=>'Desember');
-                foreach ($months as $key=>$month) {
-                    echo '<option value="' . esc_attr($key) . '">' . esc_html($month) . '</option>';
-                }
-                ?>
             </select>
             <h5><br><br>TYDPERK</h5>
             <input type="text" id="start-date" placeholder="Begindatum">

--- a/voelgoed-events-calendar.php
+++ b/voelgoed-events-calendar.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Voelgoed Events Calendar
  * Description: Display events with filters using Elementor.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Example
  */
 


### PR DESCRIPTION
## Summary
- add settings page and update plugin version
- use REST API with transient caching
- conditionally enqueue assets and integrate Flatpickr
- support deep linking and dynamic filter options
- provide Gutenberg block

## Testing
- `php -l voelgoed-events-calendar.php`
- `php -l includes/class-voelgoed-events-calendar.php`
- `php -l templates/shortcode.php`


------
https://chatgpt.com/codex/tasks/task_e_6878b7114ddc832a9df7531d4894503c