### PR TITLE
Enhance Voelgoed Events Calendar plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,9 @@
 - Switched AJAX to REST API with transient caching.
 - Conditional asset loading and Flatpickr integration.
 - Added Gutenberg block and deep-linking via URL params.
+
+## 1.2.0
+- Load assets only when shortcode or block is used.
+- Added helper functions with filters for towns and months.
+- Dynamic Flatpickr loading with native date input fallback.
+- Settings page now includes post type selection and datepicker toggle.

--- a/assets/js/events-calendar.js
+++ b/assets/js/events-calendar.js
@@ -8,9 +8,33 @@ document.addEventListener('DOMContentLoaded', function () {
     const monthFilter = document.getElementById('month-filter');
     const townFilter = document.getElementById('town-filter');
 
-    if (vgEvents.useDatepicker && window.flatpickr) {
-        flatpickr(startDate, {dateFormat: 'Y-m-d'});
-        flatpickr(endDate, {dateFormat: 'Y-m-d'});
+    function supportsDateInput() {
+        const input = document.createElement('input');
+        input.setAttribute('type', 'date');
+        const value = 'not-a-date';
+        input.setAttribute('value', value);
+        return input.value !== value;
+    }
+
+    if (vgEvents.useDatepicker) {
+        if (supportsDateInput()) {
+            startDate.type = 'date';
+            endDate.type = 'date';
+        } else {
+            const link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = vgEvents.flatpickr_css;
+            document.head.appendChild(link);
+            const script = document.createElement('script');
+            script.src = vgEvents.flatpickr_js;
+            script.onload = function () {
+                if (window.flatpickr) {
+                    flatpickr(startDate, { dateFormat: 'Y-m-d' });
+                    flatpickr(endDate, { dateFormat: 'Y-m-d' });
+                }
+            };
+            document.head.appendChild(script);
+        }
     }
 
     if (vgEvents.towns && vgEvents.towns.length) {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Helper functions for Voelgoed Events Calendar.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Get list of towns.
+ *
+ * @return array
+ */
+function voelgoed_events_get_towns() {
+    global $wpdb;
+    $results = $wpdb->get_col( "SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key='dorpstad' AND meta_value<>'' ORDER BY meta_value ASC" );
+    $towns = array_values( array_filter( $results ) );
+    /**
+     * Filter the list of towns.
+     *
+     * @param array $towns Array of town names.
+     */
+    return apply_filters( 'voelgoed_events_towns', $towns );
+}
+
+/**
+ * Get list of months based on event meta.
+ *
+ * @return array
+ */
+function voelgoed_events_get_months() {
+    global $wpdb;
+    $dates = $wpdb->get_col( "SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key='datum' AND meta_value<>''" );
+    $months = [];
+    foreach ( $dates as $d ) {
+        $m = date( 'm', strtotime( $d ) );
+        $months[ $m ] = $m;
+    }
+    ksort( $months );
+    $months = array_keys( $months );
+    /**
+     * Filter the list of months.
+     *
+     * @param array $months Array of month numbers.
+     */
+    return apply_filters( 'voelgoed_events_months', $months );
+}

--- a/voelgoed-events-calendar.php
+++ b/voelgoed-events-calendar.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Voelgoed Events Calendar
  * Description: Display events with filters using Elementor.
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Example
  */
 
@@ -10,4 +10,5 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+require_once plugin_dir_path( __FILE__ ) . 'includes/helpers.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-voelgoed-events-calendar.php';


### PR DESCRIPTION
## Summary
- load plugin helpers
- refactor settings and post type configuration
- add helper functions for towns/months with filters
- dynamically load Flatpickr only when needed
- update changelog

## Testing
- `php -l voelgoed-events-calendar.php`
- `php -l templates/shortcode.php`
- `php -l includes/helpers.php`
- `php -l includes/class-voelgoed-events-calendar.php`

------
https://chatgpt.com/codex/tasks/task_e_6878bf806a84832a8d025b7371fef32d