### PR TITLE
Improve caching and rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,11 @@
 - Added helper functions with filters for towns and months.
 - Dynamic Flatpickr loading with native date input fallback.
 - Settings page now includes post type selection and datepicker toggle.
+
+## 1.3.0
+- Switched to wp_cache_* for Redis-compatible caching.
+- REST responses cached with object cache and cache_bust support.
+- Added cache clearing on event save.
+- Server-side render of first page for better page caching.
+- Preload Flatpickr assets when enabled.
+- Improved Elementor detection and added REST nonce security.

--- a/assets/js/events-calendar.js
+++ b/assets/js/events-calendar.js
@@ -85,7 +85,8 @@ document.addEventListener('DOMContentLoaded', function () {
                 month: month,
                 town: town,
                 template_id: vgEvents.template_id,
-                paged: page
+                paged: page,
+                _wpnonce: vgEvents.nonce
             });
             const response = await fetch(vgEvents.rest_url + '?' + params.toString());
             const data = await response.json();

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -12,9 +12,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array
  */
 function voelgoed_events_get_towns() {
+    $cached = wp_cache_get( 'vg_towns', 'vg_events' );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
     global $wpdb;
     $results = $wpdb->get_col( "SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key='dorpstad' AND meta_value<>'' ORDER BY meta_value ASC" );
     $towns = array_values( array_filter( $results ) );
+    wp_cache_set( 'vg_towns', $towns, 'vg_events', HOUR_IN_SECONDS );
+
     /**
      * Filter the list of towns.
      *
@@ -29,6 +36,11 @@ function voelgoed_events_get_towns() {
  * @return array
  */
 function voelgoed_events_get_months() {
+    $cached = wp_cache_get( 'vg_months', 'vg_events' );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
     global $wpdb;
     $dates = $wpdb->get_col( "SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key='datum' AND meta_value<>''" );
     $months = [];
@@ -38,6 +50,8 @@ function voelgoed_events_get_months() {
     }
     ksort( $months );
     $months = array_keys( $months );
+    wp_cache_set( 'vg_months', $months, 'vg_events', HOUR_IN_SECONDS );
+
     /**
      * Filter the list of months.
      *

--- a/templates/shortcode.php
+++ b/templates/shortcode.php
@@ -42,7 +42,14 @@ $post_types = isset($this) ? $this->post_types : [];
         </div>
     </div>
     <div class="content-and-pagination">
-        <div id="elementor-loop-content" class="content"></div>
+        <div id="elementor-loop-content" class="content">
+            <?php
+            $no_filters = empty($_GET['search']) && empty($_GET['month']) && empty($_GET['town']) && empty($_GET['start']) && empty($_GET['end']) && empty($_GET['selected_post_type']);
+            if ( $no_filters && isset( $this ) ) {
+                echo $this->render_events();
+            }
+            ?>
+        </div>
         <div class="pagination-wrapper">
             <div id="pagination-controls" class="pagination-controls">
                 <button id="prev-page" disabled>Vorige</button>

--- a/voelgoed-events-calendar.php
+++ b/voelgoed-events-calendar.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Voelgoed Events Calendar
  * Description: Display events with filters using Elementor.
- * Version: 1.2.0
+ * Version: 1.3.0
  * Author: Example
  */
 


### PR DESCRIPTION
## Summary
- replace transients with Redis-friendly wp_cache functions
- add permission checks, nonce, and cache invalidation hooks
- preload Flatpickr assets
- render first page server-side for cache hits
- improve Elementor detection and REST fetching

## Testing
- `php -l includes/helpers.php`
- `php -l includes/class-voelgoed-events-calendar.php`
- `php -l voelgoed-events-calendar.php`
- `php -l templates/shortcode.php`


------
https://chatgpt.com/codex/tasks/task_e_6878cefa3ba4832ab611acd8d24daf43