### PR TITLE
Fix ordering and add debug option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,7 @@
 - Added dynamic CPT filtering and label exposure.
 - Enhanced admin settings UI and grouped controls.
 - Prepared plugin for Redis object caching and future metadata extensions.
+
+## 1.4.1
+- Fixed initial event sorting and future-date filtering.
+- Improved Elementor loop rendering and added optional debug mode.

--- a/assets/js/events-calendar.js
+++ b/assets/js/events-calendar.js
@@ -159,6 +159,17 @@ class VGEventsCalendar {
       this.totalPages = data.total_pages || 1;
       this.currentPage = data.current_page || 1;
       this.updatePagination();
+      if (this.config.debug && data.debug) {
+        console.log('VG Events Debug:', data.debug);
+        const dbg = document.getElementById('vg-events-debug');
+        if (dbg) {
+          dbg.style.display = 'block';
+          dbg.textContent = JSON.stringify(data.debug, null, 2);
+        }
+      } else {
+        const dbg = document.getElementById('vg-events-debug');
+        if (dbg) dbg.style.display = 'none';
+      }
     } catch (err) {
       console.error(err);
       container.innerHTML = '<p>Error loading content. Please try again.</p>';

--- a/templates/shortcode.php
+++ b/templates/shortcode.php
@@ -58,5 +58,6 @@ $post_types = isset($this) ? $this->post_types : [];
                 <button id="next-page">Volgende</button>
             </div>
         </div>
+        <pre id="vg-events-debug" style="display:none; background:#f5f5f5; padding:10px; border:1px solid #ccc; white-space:pre-wrap;"></pre>
     </div>
 </div>

--- a/voelgoed-events-calendar.php
+++ b/voelgoed-events-calendar.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Voelgoed Events Calendar
  * Description: Display events with filters using Elementor.
- * Version: 1.4.0
+ * Version: 1.4.1
  * Author: Example
  */
 


### PR DESCRIPTION
## Summary
- improve event date parsing and sorting
- add optional debug mode setting
- pass debug info to JS and display when enabled
- show debug results under the event list
- bump version to 1.4.1

## Testing
- `php -l ./includes/helpers.php`
- `php -l ./includes/class-voelgoed-events-calendar.php`
- `php -l ./voelgoed-events-calendar.php`
- `php -l ./templates/shortcode.php`

------
https://chatgpt.com/codex/tasks/task_e_687916485c9c832a97052a25550896fa