### PR TITLE
Update plugin to version 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,11 +60,11 @@
 - Added `vg_events_schema_event` filter to customize schema data.
 - Cached loops now include the schema markup for better SEO.
 
-## 1.8.0
+## 1.8.1
 - Added persistent WP_Query caching with object cache and cache headers.
 - Included organizer, performer and offers in JSON-LD data.
 - REST responses now expose cache hit status when debug mode is enabled.
-- Bumped plugin version to 1.8.0.
+- Bumped plugin version to 1.8.1.
 
 ## 4.1.0
 - OPcache preloading for core plugin files.

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ ALTER TABLE wp_postmeta ADD INDEX idx_meta_datum (meta_key(191), meta_value(10))
 ALTER TABLE wp_postmeta ADD INDEX idx_meta_venue (meta_key(191), meta_value(50));
 ```
 
-Run these commands via WP-CLI or phpMyAdmin before activating version 4.1.
+Run these commands via WP-CLI or phpMyAdmin before activating version 1.8.1.

--- a/includes/class-voelgoed-events-calendar.php
+++ b/includes/class-voelgoed-events-calendar.php
@@ -5,7 +5,7 @@ if (!defined('ABSPATH')) {
 
 class Voelgoed_Events_Calendar {
     private static $instance = null;
-    private $version = '4.1.0';
+    private $version = '1.8.1';
     /** Duration in seconds for cached queries and renders */
     private $cache_ttl = 300;
     /** Cache group for object caching */

--- a/voelgoed-events-calendar.php
+++ b/voelgoed-events-calendar.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Voelgoed Events Calendar
  * Description: Display events with filters using Elementor.
- * Version: 4.1.0
+ * Version: 1.8.1
  * Author: Example
  */
 


### PR DESCRIPTION
## Summary
- bump plugin references from `4.1.0` to `1.8.1`
- update changelog for version 1.8.1
- adjust README version notice

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_687d03e3da04832aa4c0197a5eea7322