### PR TITLE
Implement cache manager and template overrides

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ruleset name="VoelgoedEvents">
+    <rule ref="WordPress" />
+    <file>voelgoed-events-calendar.php</file>
+    <file>includes</file>
+    <file>templates</file>
+</ruleset>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@
 - REST responses now expose cache hit status when debug mode is enabled.
 - Bumped plugin version to 1.8.1.
 
+## 1.8.2
+- Added `VG_Events_Cache` class with invalidate helper.
+- Template files now support theme overrides via `vg_events_template_path` filter.
+- REST responses include `ETag` and `Last-Modified` headers.
+- Bumped plugin version to 1.8.2.
+
 ## 4.1.0
 - OPcache preloading for core plugin files.
 - Switched caching to persistent Redis/object cache with `vg_events` group.

--- a/includes/class-vg-events-cache.php
+++ b/includes/class-vg-events-cache.php
@@ -1,0 +1,49 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class VG_Events_Cache {
+    /** @var string */
+    protected $group = 'vg_events';
+
+    /**
+     * Store a value in cache.
+     *
+     * @param string $key Cache key.
+     * @param mixed  $data Data to store.
+     * @param int    $ttl  Time to live in seconds.
+     */
+    public function set( $key, $data, $ttl = 0 ) {
+        wp_cache_set( $key, $data, $this->group, $ttl );
+    }
+
+    /**
+     * Retrieve a cached value.
+     *
+     * @param string $key Cache key.
+     * @return mixed
+     */
+    public function get( $key ) {
+        return wp_cache_get( $key, $this->group );
+    }
+
+    /**
+     * Invalidate cache entries for a prefix.
+     *
+     * @param string $name Cache name suffix.
+     */
+    public function invalidate( $name ) {
+        $key = 'vg_events_cached_' . sanitize_key( $name );
+        delete_transient( $key );
+        wp_cache_delete( $key, $this->group );
+    }
+}
+
+function vg_events_cache() {
+    static $instance = null;
+    if ( null === $instance ) {
+        $instance = new VG_Events_Cache();
+    }
+    return $instance;
+}

--- a/includes/class-voelgoed-events-calendar.php
+++ b/includes/class-voelgoed-events-calendar.php
@@ -104,7 +104,7 @@ class Voelgoed_Events_Calendar {
 
     public function shortcode() {
         ob_start();
-        include plugin_dir_path(__FILE__) . '../templates/shortcode.php';
+        include vg_events_template_path( 'shortcode.php' );
         return ob_get_clean();
     }
 
@@ -130,6 +130,9 @@ class Voelgoed_Events_Calendar {
         if ( $this->debug ) {
             $resp->header( 'X-VG-Cache', $from_cache ? 'HIT' : 'MISS' );
         }
+        $etag = md5( serialize( $response ) );
+        $resp->header( 'ETag', $etag );
+        $resp->header( 'Last-Modified', gmdate( 'D, d M Y H:i:s', time() ) . ' GMT' );
         return $resp;
     }
 
@@ -253,7 +256,7 @@ class Voelgoed_Events_Calendar {
                 setup_postdata($post);
                 $vg_events_debug = $this->debug;
                 ob_start();
-                include plugin_dir_path(__FILE__) . '/../templates/vg-events-loop.php';
+                include vg_events_template_path( 'vg-events-loop.php' );
                 $html = ob_get_clean();
                 echo $html;
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -122,14 +122,28 @@ function vg_events_get_post_type_labels() {
 }
 
 /**
+ * Locate a template with theme override support.
+ *
+ * @param string $file Template file name.
+ * @return string
+ */
+function vg_events_template_path( $file ) {
+    $located = locate_template( $file );
+    if ( ! $located ) {
+        $located = plugin_dir_path( __FILE__ ) . '../templates/' . $file;
+    }
+    return apply_filters( 'vg_events_template_path', $located, $file );
+}
+
+/**
  * Clear cached town and month lists when supported posts are saved.
  */
 function vg_events_clear_cache_on_save( $post_id, $post ) {
     if ( ! $post || ! in_array( $post->post_type, vg_events_get_supported_post_types(), true ) ) {
         return;
     }
-    delete_transient( 'vg_events_cached_towns' );
-    delete_transient( 'vg_events_cached_months' );
+    vg_events_cache()->invalidate( 'towns' );
+    vg_events_cache()->invalidate( 'months' );
     global $wpdb;
     $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_vg_events_%'" );
     $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_site_transient_vg_events_%'" );
@@ -144,6 +158,8 @@ function vg_events_invalidate_cache() {
     global $wpdb;
     $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_vg_events_%'" );
     $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_site_transient_vg_events_%'" );
+    vg_events_cache()->invalidate( 'towns' );
+    vg_events_cache()->invalidate( 'months' );
     wp_cache_flush();
 }
 

--- a/voelgoed-events-calendar.php
+++ b/voelgoed-events-calendar.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Voelgoed Events Calendar
  * Description: Display events with filters using Elementor.
- * Version: 1.8.1
+ * Version: 1.8.2
  * Author: Example
  */
 
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/helpers.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-vg-events-cache.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-voelgoed-events-calendar.php';
 
 register_activation_hook( __FILE__, function() {


### PR DESCRIPTION
## Summary
- introduce `VG_Events_Cache` class
- allow theme template overrides via `vg_events_template_path`
- add caching invalidation calls to helpers
- send `ETag` and `Last-Modified` on REST responses
- include PHPCS config and bump version to 1.8.2

## Testing
- `php -l voelgoed-events-calendar.php`
- `php -l includes/class-voelgoed-events-calendar.php`
- `php -l includes/helpers.php`
- `php -l includes/class-vg-events-cache.php`
- `php -l templates/vg-events-loop.php`
- `php -l templates/shortcode.php`

------
https://chatgpt.com/codex/tasks/task_e_687d0f0654ec832a8ecc24873d3c01d9